### PR TITLE
Golang cli for elasticsearch gcs snapshot restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ What it does:
 - Reads repository metadata (`index.latest` and `index-N`) to pick a snapshot that matches a given timeframe and optional grep pattern.
 - Generates a restore request JSON body in the destination bucket under `restore-requests/` that you can POST to Elasticsearch's restore API.
 
+It also supports local directories as source and/or destination, so you can copy from/to the filesystem instead of GCS.
+
 Inputs (flags):
 - `--src-service-account`: path to source bucket service account JSON.
 - `--src-bucket`: source GCS bucket name.
@@ -20,7 +22,7 @@ Build:
 go build -o rockez-script
 ```
 
-Run:
+Run (GCS -> GCS):
 ```bash
 ./rockez-script \
   --src-service-account=/path/to/src.json \
@@ -30,6 +32,17 @@ Run:
   --timeframe=2025-09-01T00:00:00Z/2025-09-10T23:59:59Z \
   --grep=index-prefix-
 ```
+
+Run (Local -> Local):
+```bash
+./rockez-script \
+  --src-dir=/path/to/src-repo \
+  --dest-dir=/path/to/dest-repo \
+  --timeframe=2025-09-01T00:00:00Z/2025-09-10T23:59:59Z \
+  --grep='myindex-.*'
+```
+
+Run (Local -> GCS) or (GCS -> Local): provide the appropriate pair for the side you use (dir or bucket+service-account), but not both for the same side.
 
 Notes:
 - The repository is copied entirely to keep restore compatibility. The timeframe/grep are used to suggest a snapshot and indices filter for the restore API payload that is written as JSON.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+## rockez-script
+
+Simple Go CLI to prepare Elasticsearch restore from a GCS snapshot repository.
+
+What it does:
+- Copies the entire snapshot repository from a source GCS bucket to a destination GCS bucket (server-side copy).
+- Reads repository metadata (`index.latest` and `index-N`) to pick a snapshot that matches a given timeframe and optional grep pattern.
+- Generates a restore request JSON body in the destination bucket under `restore-requests/` that you can POST to Elasticsearch's restore API.
+
+Inputs (flags):
+- `--src-service-account`: path to source bucket service account JSON.
+- `--src-bucket`: source GCS bucket name.
+- `--dest-service-account`: path to destination bucket service account JSON.
+- `--dest-bucket`: destination GCS bucket name.
+- `--timeframe`: RFC3339 start/end, e.g. `2025-09-01T00:00:00Z/2025-09-10T23:59:59Z`.
+- `--grep`: regex or plain text to match snapshot name or contained index names.
+
+Build:
+```bash
+go build -o rockez-script
+```
+
+Run:
+```bash
+./rockez-script \
+  --src-service-account=/path/to/src.json \
+  --src-bucket=your-src-bucket \
+  --dest-service-account=/path/to/dest.json \
+  --dest-bucket=your-dest-bucket \
+  --timeframe=2025-09-01T00:00:00Z/2025-09-10T23:59:59Z \
+  --grep=index-prefix-
+```
+
+Notes:
+- The repository is copied entirely to keep restore compatibility. The timeframe/grep are used to suggest a snapshot and indices filter for the restore API payload that is written as JSON.
+- Ensure the destination repo is registered in Elasticsearch (via `PUT _snapshot/{name}`) pointing to the destination bucket before running restore.

--- a/README.md
+++ b/README.md
@@ -47,3 +47,23 @@ Run (Local -> GCS) or (GCS -> Local): provide the appropriate pair for the side 
 Notes:
 - The repository is copied entirely to keep restore compatibility. The timeframe/grep are used to suggest a snapshot and indices filter for the restore API payload that is written as JSON.
 - Ensure the destination repo is registered in Elasticsearch (via `PUT _snapshot/{name}`) pointing to the destination bucket before running restore.
+
+### Local test with Docker Compose
+
+This repo includes a simple local verification using Docker Compose and a shell script.
+
+Requirements: Docker, Docker Compose, `jq`.
+
+Steps:
+```bash
+go build -o rockez-script
+bash test/run.sh
+```
+
+What it does:
+- Starts a single-node Elasticsearch with a mounted local snapshot repo at `./snapshots`.
+- Indexes seed documents from `test/seed.json`.
+- Creates a snapshot of indices (`orders-*`, `users-*`).
+- Runs the CLI to copy the repo to `./snapshots_copy`, generating a restore request that filters with `--grep 'orders-.*'` and renames to `orders-restored-$1`.
+- Registers the copied repo and restores it into Elasticsearch.
+- Prints `_cat/indices` so you can verify `orders-restored-*` indices exist.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.8"
+
+services:
+  es01:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.3
+    container_name: es01
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - path.repo=/snapshots
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - "9200:9200"
+    volumes:
+      - esdata01:/usr/share/elasticsearch/data
+      - ./snapshots:/snapshots
+
+volumes:
+  esdata01:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module rockez-script
+
+go 1.22.0
+
+require (
+	cloud.google.com/go/storage v1.40.0
+	google.golang.org/api v0.201.0
+)

--- a/main.go
+++ b/main.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+type snapshotMetadata struct {
+	Snapshot          string   `json:"snapshot"`
+	UUID             string   `json:"uuid"`
+	Indices          []string `json:"indices"`
+	StartTimeMillis  int64    `json:"start_time_millis"`
+	EndTimeMillis    int64    `json:"end_time_millis"`
+}
+
+type indexFile struct {
+	Snapshots []snapshotMetadata `json:"snapshots"`
+}
+
+type restoreRequestBody struct {
+	Indices            string `json:"indices,omitempty"`
+	IgnoreUnavailable  bool   `json:"ignore_unavailable"`
+	IncludeGlobalState bool   `json:"include_global_state"`
+	IncludeAliases     bool   `json:"include_aliases"`
+	Partial            bool   `json:"partial"`
+}
+
+func main() {
+	var (
+		srcCredPath  string
+		srcBucket    string
+		dstCredPath  string
+		dstBucket    string
+		timeframeArg string
+		grepArg      string
+		maxWorkers   int
+	)
+
+	flag.StringVar(&srcCredPath, "src-service-account", "", "Path to source GCS service account JSON key file")
+	flag.StringVar(&srcBucket, "src-bucket", "", "Source GCS bucket name containing the Elasticsearch snapshot repo")
+	flag.StringVar(&dstCredPath, "dest-service-account", "", "Path to destination GCS service account JSON key file")
+	flag.StringVar(&dstBucket, "dest-bucket", "", "Destination GCS bucket to receive copy and restore request")
+	flag.StringVar(&timeframeArg, "timeframe", "", "Timeframe filter RFC3339/RFC3339 (e.g. 2025-09-01T00:00:00Z/2025-09-10T23:59:59Z)")
+	flag.StringVar(&grepArg, "grep", "", "Substring or regex to match snapshot name or index names")
+	flag.IntVar(&maxWorkers, "concurrency", 16, "Max concurrent copies")
+	flag.Parse()
+
+	if srcCredPath == "" || srcBucket == "" || dstCredPath == "" || dstBucket == "" {
+		log.Fatal("All of --src-service-account, --src-bucket, --dest-service-account, --dest-bucket are required")
+	}
+
+	var (
+		start time.Time
+		end   time.Time
+		err   error
+	)
+	if timeframeArg != "" {
+		start, end, err = parseTimeframe(timeframeArg)
+		if err != nil {
+			log.Fatalf("invalid --timeframe: %v", err)
+		}
+	}
+
+	var grepMatcher *regexp.Regexp
+	if grepArg != "" {
+		// Treat input as regex if it compiles, else escape and use as literal substring match via regex
+		grepMatcher, err = regexp.Compile(grepArg)
+		if err != nil {
+			grepMatcher = regexp.MustCompile(regexp.QuoteMeta(grepArg))
+		}
+	}
+
+	ctx := context.Background()
+	srcClient, err := storage.NewClient(ctx, option.WithCredentialsFile(srcCredPath))
+	if err != nil {
+		log.Fatalf("failed to init source storage client: %v", err)
+	}
+	defer srcClient.Close()
+
+	dstClient, err := storage.NewClient(ctx, option.WithCredentialsFile(dstCredPath))
+	if err != nil {
+		log.Fatalf("failed to init destination storage client: %v", err)
+	}
+	defer dstClient.Close()
+
+	// Copy the entire repository to ensure restore-compatibility.
+	if err := copyAllObjects(ctx, srcClient, srcBucket, dstClient, dstBucket, maxWorkers); err != nil {
+		log.Fatalf("failed to copy repository: %v", err)
+	}
+
+	// Attempt to determine the best snapshot within timeframe/grep for a restore request.
+	selectedSnapshot, indicesPattern := selectSnapshotForRestore(ctx, srcClient, srcBucket, start, end, grepMatcher)
+	if selectedSnapshot == "" {
+		log.Printf("warning: no snapshot matched timeframe/grep; generating generic restore request")
+	}
+
+	// Compose a restore request body and store it in the destination bucket.
+	req := restoreRequestBody{
+		Indices:            indicesPattern,
+		IgnoreUnavailable:  true,
+		IncludeGlobalState: false,
+		IncludeAliases:     true,
+		Partial:            false,
+	}
+	if err := writeRestoreRequest(ctx, dstClient, dstBucket, selectedSnapshot, req); err != nil {
+		log.Fatalf("failed to write restore request: %v", err)
+	}
+
+	log.Printf("Done. Repository copied to gs://%s. Restore request JSON written.", dstBucket)
+}
+
+func parseTimeframe(tf string) (time.Time, time.Time, error) {
+	parts := strings.Split(tf, "/")
+	if len(parts) != 2 {
+		return time.Time{}, time.Time{}, fmt.Errorf("expected start/end RFC3339, got %q", tf)
+	}
+	start, err := time.Parse(time.RFC3339, strings.TrimSpace(parts[0]))
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("invalid start time: %w", err)
+	}
+	end, err := time.Parse(time.RFC3339, strings.TrimSpace(parts[1]))
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("invalid end time: %w", err)
+	}
+	if !end.After(start) {
+		return time.Time{}, time.Time{}, errors.New("end must be after start")
+	}
+	return start, end, nil
+}
+
+func copyAllObjects(ctx context.Context, srcClient *storage.Client, srcBucket string, dstClient *storage.Client, dstBucket string, maxWorkers int) error {
+	src := srcClient.Bucket(srcBucket)
+	dst := dstClient.Bucket(dstBucket)
+
+	// Ensure destination bucket exists (no-op if it already exists and we have perms to access)
+	if _, err := dst.Attrs(ctx); err != nil {
+		return fmt.Errorf("destination bucket %s not accessible: %w", dstBucket, err)
+	}
+
+	it := src.Objects(ctx, &storage.Query{})
+	objCh := make(chan *storage.ObjectAttrs, maxWorkers*2)
+	var wg sync.WaitGroup
+	var copyErr error
+	var mu sync.Mutex
+
+	worker := func() {
+		defer wg.Done()
+		for attrs := range objCh {
+			// Preserve object name
+			dstObj := dst.Object(attrs.Name)
+			srcObj := src.Object(attrs.Name)
+			copier := dstObj.CopierFrom(srcObj)
+			// Preserve metadata and contentType if possible
+			copier.ContentType = attrs.ContentType
+			if _, err := copier.Run(ctx); err != nil {
+				mu.Lock()
+				if copyErr == nil {
+					copyErr = fmt.Errorf("copy %s: %w", attrs.Name, err)
+				}
+				mu.Unlock()
+			}
+		}
+	}
+
+	for i := 0; i < maxWorkers; i++ {
+		wg.Add(1)
+		go worker()
+	}
+
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			close(objCh)
+			wg.Wait()
+			return fmt.Errorf("list objects: %w", err)
+		}
+		objCh <- attrs
+	}
+	close(objCh)
+	wg.Wait()
+
+	return copyErr
+}
+
+func selectSnapshotForRestore(ctx context.Context, client *storage.Client, bucket string, start, end time.Time, grep *regexp.Regexp) (string, string) {
+	// Defaults
+	indicesPattern := "*"
+	selected := ""
+
+	// Try reading index.latest and index-N
+	idxNName, err := readIndexLatest(ctx, client, bucket)
+	if err != nil {
+		log.Printf("info: cannot read index.latest/index-N: %v", err)
+		return selected, indicesPattern
+	}
+	idx, err := readIndexFile(ctx, client, bucket, idxNName)
+	if err != nil {
+		log.Printf("info: cannot read %s: %v", idxNName, err)
+		return selected, indicesPattern
+	}
+
+	// Filter snapshots by timeframe and optional grep (against snapshot name or any index name)
+	var candidates []snapshotMetadata
+	for _, s := range idx.Snapshots {
+		if start.IsZero() == false || end.IsZero() == false {
+			if s.StartTimeMillis == 0 {
+				continue
+			}
+			st := time.UnixMilli(s.StartTimeMillis)
+			if st.Before(start) || st.After(end) {
+				continue
+			}
+		}
+		if grep != nil {
+			matched := grep.MatchString(s.Snapshot)
+			if !matched {
+				for _, indexName := range s.Indices {
+					if grep.MatchString(indexName) {
+						matched = true
+						break
+					}
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+		candidates = append(candidates, s)
+	}
+
+	if len(candidates) == 0 {
+		return "", indicesPattern
+	}
+
+	// Pick the newest by start time
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].StartTimeMillis < candidates[j].StartTimeMillis })
+	choice := candidates[len(candidates)-1]
+	selected = choice.Snapshot
+
+	// If grep was provided and matched indices, convert it to indices pattern for restore body
+	if grep != nil {
+		// Use the provided string as-is as a simple pattern if it doesn't look like a regex meta
+		indicesPattern = grep.String()
+	}
+
+	return selected, indicesPattern
+}
+
+func readIndexLatest(ctx context.Context, client *storage.Client, bucket string) (string, error) {
+	b := client.Bucket(bucket)
+	r, err := b.Object("index.latest").NewReader(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		return "", errors.New("empty index.latest")
+	}
+	line := strings.TrimSpace(scanner.Text())
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("index-%s", line), nil
+}
+
+func readIndexFile(ctx context.Context, client *storage.Client, bucket, name string) (indexFile, error) {
+	b := client.Bucket(bucket)
+	r, err := b.Object(name).NewReader(ctx)
+	if err != nil {
+		return indexFile{}, err
+	}
+	defer r.Close()
+	var idx indexFile
+	if err := json.NewDecoder(r).Decode(&idx); err != nil {
+		return indexFile{}, err
+	}
+	return idx, nil
+}
+
+func writeRestoreRequest(ctx context.Context, client *storage.Client, bucket, snapshot string, body restoreRequestBody) error {
+	b := client.Bucket(bucket)
+	when := time.Now().UTC().Format("20060102T150405Z")
+	base := "restore-requests"
+	name := fmt.Sprintf("%s/restore_%s.json", base, when)
+	if snapshot != "" {
+		name = fmt.Sprintf("%s/restore_%s_%s.json", base, sanitizeForPath(snapshot), when)
+	}
+	w := b.Object(name).NewWriter(ctx)
+	w.ContentType = "application/json"
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(body); err != nil {
+		_ = w.Close()
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+
+	// Also write a small helper text with the REST call format
+	cmd := buildRestoreCurl(snapshot)
+	textName := strings.TrimSuffix(name, path.Ext(name)) + ".txt"
+	w2 := b.Object(textName).NewWriter(ctx)
+	w2.ContentType = "text/plain"
+	if _, err := io.WriteString(w2, cmd+"\n"); err != nil {
+		_ = w2.Close()
+		return err
+	}
+	return w2.Close()
+}
+
+func buildRestoreCurl(snapshot string) string {
+	if snapshot == "" {
+		return "# Example: POST /_snapshot/{REPOSITORY}/{SNAPSHOT}/_restore -d @restore.json"
+	}
+	return fmt.Sprintf("# Run after registering GCS repo in Elasticsearch\n# Replace {REPOSITORY} with your repo name that points to gs:// in cluster\n# Assuming file is restore-request/restore_%s.json\n# curl -X POST $ES/_snapshot/{REPOSITORY}/%s/_restore -H 'Content-Type: application/json' --data-binary @restore.json", snapshot, snapshot)
+}
+
+func sanitizeForPath(name string) string {
+	// Keep it simple: replace path separators and spaces
+	replacer := strings.NewReplacer("/", "-", "\\", "-", " ", "_")
+	return replacer.Replace(name)
+}

--- a/main.go
+++ b/main.go
@@ -1,24 +1,26 @@
 package main
 
 import (
-	"bufio"
-	"context"
-	"encoding/json"
-	"errors"
-	"flag"
-	"fmt"
-	"io"
-	"log"
-	"path"
-	"regexp"
-	"sort"
-	"strings"
-	"sync"
-	"time"
+    "bufio"
+    "context"
+    "encoding/json"
+    "errors"
+    "flag"
+    "fmt"
+    "io"
+    "log"
+    "os"
+    "path"
+    "path/filepath"
+    "regexp"
+    "sort"
+    "strings"
+    "sync"
+    "time"
 
-	"cloud.google.com/go/storage"
-	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
+    "cloud.google.com/go/storage"
+    "google.golang.org/api/iterator"
+    "google.golang.org/api/option"
 )
 
 type snapshotMetadata struct {
@@ -45,8 +47,10 @@ func main() {
 	var (
 		srcCredPath  string
 		srcBucket    string
+        srcDir       string
 		dstCredPath  string
 		dstBucket    string
+        dstDir       string
 		timeframeArg string
 		grepArg      string
 		maxWorkers   int
@@ -54,16 +58,35 @@ func main() {
 
 	flag.StringVar(&srcCredPath, "src-service-account", "", "Path to source GCS service account JSON key file")
 	flag.StringVar(&srcBucket, "src-bucket", "", "Source GCS bucket name containing the Elasticsearch snapshot repo")
+    flag.StringVar(&srcDir, "src-dir", "", "Source local directory containing the Elasticsearch snapshot repo (alternative to --src-bucket)")
 	flag.StringVar(&dstCredPath, "dest-service-account", "", "Path to destination GCS service account JSON key file")
 	flag.StringVar(&dstBucket, "dest-bucket", "", "Destination GCS bucket to receive copy and restore request")
+    flag.StringVar(&dstDir, "dest-dir", "", "Destination local directory to receive copy and restore request (alternative to --dest-bucket)")
 	flag.StringVar(&timeframeArg, "timeframe", "", "Timeframe filter RFC3339/RFC3339 (e.g. 2025-09-01T00:00:00Z/2025-09-10T23:59:59Z)")
 	flag.StringVar(&grepArg, "grep", "", "Substring or regex to match snapshot name or index names")
 	flag.IntVar(&maxWorkers, "concurrency", 16, "Max concurrent copies")
 	flag.Parse()
 
-	if srcCredPath == "" || srcBucket == "" || dstCredPath == "" || dstBucket == "" {
-		log.Fatal("All of --src-service-account, --src-bucket, --dest-service-account, --dest-bucket are required")
-	}
+    // Validate source
+    if srcDir == "" {
+        if srcBucket == "" || srcCredPath == "" {
+            log.Fatal("Provide either --src-dir or both --src-bucket and --src-service-account")
+        }
+    } else {
+        if srcBucket != "" || srcCredPath != "" {
+            log.Fatal("Use either local source (--src-dir) or GCS source (--src-bucket + --src-service-account), not both")
+        }
+    }
+    // Validate destination
+    if dstDir == "" {
+        if dstBucket == "" || dstCredPath == "" {
+            log.Fatal("Provide either --dest-dir or both --dest-bucket and --dest-service-account")
+        }
+    } else {
+        if dstBucket != "" || dstCredPath != "" {
+            log.Fatal("Use either local destination (--dest-dir) or GCS destination (--dest-bucket + --dest-service-account), not both")
+        }
+    }
 
 	var (
 		start time.Time
@@ -86,26 +109,49 @@ func main() {
 		}
 	}
 
-	ctx := context.Background()
-	srcClient, err := storage.NewClient(ctx, option.WithCredentialsFile(srcCredPath))
-	if err != nil {
-		log.Fatalf("failed to init source storage client: %v", err)
-	}
-	defer srcClient.Close()
+    ctx := context.Background()
 
-	dstClient, err := storage.NewClient(ctx, option.WithCredentialsFile(dstCredPath))
-	if err != nil {
-		log.Fatalf("failed to init destination storage client: %v", err)
-	}
-	defer dstClient.Close()
+    // Build source repo
+    var srcRepo Repo
+    var srcClient *storage.Client
+    if srcDir != "" {
+        srcRepo = newFSRepo(srcDir)
+    } else {
+        srcClient, err = storage.NewClient(ctx, option.WithCredentialsFile(srcCredPath))
+        if err != nil {
+            log.Fatalf("failed to init source storage client: %v", err)
+        }
+        defer srcClient.Close()
+        srcRepo = newGCSRepo(srcClient, srcBucket)
+    }
+    if err := srcRepo.EnsureAccessible(ctx); err != nil {
+        log.Fatalf("source not accessible: %v", err)
+    }
 
-	// Copy the entire repository to ensure restore-compatibility.
-	if err := copyAllObjects(ctx, srcClient, srcBucket, dstClient, dstBucket, maxWorkers); err != nil {
-		log.Fatalf("failed to copy repository: %v", err)
-	}
+    // Build destination repo
+    var dstRepo Repo
+    var dstClient *storage.Client
+    if dstDir != "" {
+        dstRepo = newFSRepo(dstDir)
+    } else {
+        dstClient, err = storage.NewClient(ctx, option.WithCredentialsFile(dstCredPath))
+        if err != nil {
+            log.Fatalf("failed to init destination storage client: %v", err)
+        }
+        defer dstClient.Close()
+        dstRepo = newGCSRepo(dstClient, dstBucket)
+    }
+    if err := dstRepo.EnsureAccessible(ctx); err != nil {
+        log.Fatalf("destination not accessible: %v", err)
+    }
 
-	// Attempt to determine the best snapshot within timeframe/grep for a restore request.
-	selectedSnapshot, indicesPattern := selectSnapshotForRestore(ctx, srcClient, srcBucket, start, end, grepMatcher)
+    // Copy the entire repository to ensure restore-compatibility.
+    if err := copyAllObjectsGeneric(ctx, srcRepo, dstRepo, maxWorkers); err != nil {
+        log.Fatalf("failed to copy repository: %v", err)
+    }
+
+    // Attempt to determine the best snapshot within timeframe/grep for a restore request.
+    selectedSnapshot, indicesPattern := selectSnapshotForRestoreGeneric(ctx, srcRepo, start, end, grepMatcher)
 	if selectedSnapshot == "" {
 		log.Printf("warning: no snapshot matched timeframe/grep; generating generic restore request")
 	}
@@ -118,11 +164,11 @@ func main() {
 		IncludeAliases:     true,
 		Partial:            false,
 	}
-	if err := writeRestoreRequest(ctx, dstClient, dstBucket, selectedSnapshot, req); err != nil {
+    if err := writeRestoreRequestGeneric(ctx, dstRepo, selectedSnapshot, req); err != nil {
 		log.Fatalf("failed to write restore request: %v", err)
 	}
 
-	log.Printf("Done. Repository copied to gs://%s. Restore request JSON written.", dstBucket)
+    log.Printf("Done. Repository copied to %s. Restore request JSON written.", dstRepo.String())
 }
 
 func parseTimeframe(tf string) (time.Time, time.Time, error) {
@@ -144,75 +190,90 @@ func parseTimeframe(tf string) (time.Time, time.Time, error) {
 	return start, end, nil
 }
 
-func copyAllObjects(ctx context.Context, srcClient *storage.Client, srcBucket string, dstClient *storage.Client, dstBucket string, maxWorkers int) error {
-	src := srcClient.Bucket(srcBucket)
-	dst := dstClient.Bucket(dstBucket)
+func copyAllObjectsGeneric(ctx context.Context, src Repo, dst Repo, maxWorkers int) error {
+    it, err := src.List(ctx)
+    if err != nil {
+        return err
+    }
+    objCh := make(chan *ObjectAttrs, maxWorkers*2)
+    var wg sync.WaitGroup
+    var copyErr error
+    var mu sync.Mutex
 
-	// Ensure destination bucket exists (no-op if it already exists and we have perms to access)
-	if _, err := dst.Attrs(ctx); err != nil {
-		return fmt.Errorf("destination bucket %s not accessible: %w", dstBucket, err)
-	}
+    worker := func() {
+        defer wg.Done()
+        for attrs := range objCh {
+            r, err := src.Reader(ctx, attrs.Name)
+            if err != nil {
+                mu.Lock()
+                if copyErr == nil {
+                    copyErr = fmt.Errorf("open src %s: %w", attrs.Name, err)
+                }
+                mu.Unlock()
+                continue
+            }
+            w, err := dst.Writer(ctx, attrs.Name, attrs.ContentType)
+            if err != nil {
+                _ = r.Close()
+                mu.Lock()
+                if copyErr == nil {
+                    copyErr = fmt.Errorf("open dst %s: %w", attrs.Name, err)
+                }
+                mu.Unlock()
+                continue
+            }
+            if _, err := io.Copy(w, r); err != nil {
+                mu.Lock()
+                if copyErr == nil {
+                    copyErr = fmt.Errorf("copy %s: %w", attrs.Name, err)
+                }
+                mu.Unlock()
+            }
+            _ = r.Close()
+            if err := w.Close(); err != nil {
+                mu.Lock()
+                if copyErr == nil {
+                    copyErr = fmt.Errorf("close dst %s: %w", attrs.Name, err)
+                }
+                mu.Unlock()
+            }
+        }
+    }
 
-	it := src.Objects(ctx, &storage.Query{})
-	objCh := make(chan *storage.ObjectAttrs, maxWorkers*2)
-	var wg sync.WaitGroup
-	var copyErr error
-	var mu sync.Mutex
+    for i := 0; i < maxWorkers; i++ {
+        wg.Add(1)
+        go worker()
+    }
 
-	worker := func() {
-		defer wg.Done()
-		for attrs := range objCh {
-			// Preserve object name
-			dstObj := dst.Object(attrs.Name)
-			srcObj := src.Object(attrs.Name)
-			copier := dstObj.CopierFrom(srcObj)
-			// Preserve metadata and contentType if possible
-			copier.ContentType = attrs.ContentType
-			if _, err := copier.Run(ctx); err != nil {
-				mu.Lock()
-				if copyErr == nil {
-					copyErr = fmt.Errorf("copy %s: %w", attrs.Name, err)
-				}
-				mu.Unlock()
-			}
-		}
-	}
-
-	for i := 0; i < maxWorkers; i++ {
-		wg.Add(1)
-		go worker()
-	}
-
-	for {
-		attrs, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			close(objCh)
-			wg.Wait()
-			return fmt.Errorf("list objects: %w", err)
-		}
-		objCh <- attrs
-	}
-	close(objCh)
-	wg.Wait()
-
-	return copyErr
+    for {
+        attrs, err := it.Next()
+        if err == iterator.Done {
+            break
+        }
+        if err != nil {
+            close(objCh)
+            wg.Wait()
+            return err
+        }
+        objCh <- attrs
+    }
+    close(objCh)
+    wg.Wait()
+    return copyErr
 }
 
-func selectSnapshotForRestore(ctx context.Context, client *storage.Client, bucket string, start, end time.Time, grep *regexp.Regexp) (string, string) {
+func selectSnapshotForRestoreGeneric(ctx context.Context, repo Repo, start, end time.Time, grep *regexp.Regexp) (string, string) {
 	// Defaults
 	indicesPattern := "*"
 	selected := ""
 
 	// Try reading index.latest and index-N
-	idxNName, err := readIndexLatest(ctx, client, bucket)
+    idxNName, err := readIndexLatestGeneric(ctx, repo)
 	if err != nil {
 		log.Printf("info: cannot read index.latest/index-N: %v", err)
 		return selected, indicesPattern
 	}
-	idx, err := readIndexFile(ctx, client, bucket, idxNName)
+    idx, err := readIndexFileGeneric(ctx, repo, idxNName)
 	if err != nil {
 		log.Printf("info: cannot read %s: %v", idxNName, err)
 		return selected, indicesPattern
@@ -265,68 +326,69 @@ func selectSnapshotForRestore(ctx context.Context, client *storage.Client, bucke
 	return selected, indicesPattern
 }
 
-func readIndexLatest(ctx context.Context, client *storage.Client, bucket string) (string, error) {
-	b := client.Bucket(bucket)
-	r, err := b.Object("index.latest").NewReader(ctx)
-	if err != nil {
-		return "", err
-	}
-	defer r.Close()
-	scanner := bufio.NewScanner(r)
-	if !scanner.Scan() {
-		return "", errors.New("empty index.latest")
-	}
-	line := strings.TrimSpace(scanner.Text())
-	if err := scanner.Err(); err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("index-%s", line), nil
+func readIndexLatestGeneric(ctx context.Context, repo Repo) (string, error) {
+    r, err := repo.Reader(ctx, "index.latest")
+    if err != nil {
+        return "", err
+    }
+    defer r.Close()
+    scanner := bufio.NewScanner(r)
+    if !scanner.Scan() {
+        return "", errors.New("empty index.latest")
+    }
+    line := strings.TrimSpace(scanner.Text())
+    if err := scanner.Err(); err != nil {
+        return "", err
+    }
+    return fmt.Sprintf("index-%s", line), nil
 }
 
-func readIndexFile(ctx context.Context, client *storage.Client, bucket, name string) (indexFile, error) {
-	b := client.Bucket(bucket)
-	r, err := b.Object(name).NewReader(ctx)
-	if err != nil {
-		return indexFile{}, err
-	}
-	defer r.Close()
-	var idx indexFile
-	if err := json.NewDecoder(r).Decode(&idx); err != nil {
-		return indexFile{}, err
-	}
-	return idx, nil
+func readIndexFileGeneric(ctx context.Context, repo Repo, name string) (indexFile, error) {
+    r, err := repo.Reader(ctx, name)
+    if err != nil {
+        return indexFile{}, err
+    }
+    defer r.Close()
+    var idx indexFile
+    if err := json.NewDecoder(r).Decode(&idx); err != nil {
+        return indexFile{}, err
+    }
+    return idx, nil
 }
 
-func writeRestoreRequest(ctx context.Context, client *storage.Client, bucket, snapshot string, body restoreRequestBody) error {
-	b := client.Bucket(bucket)
-	when := time.Now().UTC().Format("20060102T150405Z")
-	base := "restore-requests"
-	name := fmt.Sprintf("%s/restore_%s.json", base, when)
-	if snapshot != "" {
-		name = fmt.Sprintf("%s/restore_%s_%s.json", base, sanitizeForPath(snapshot), when)
-	}
-	w := b.Object(name).NewWriter(ctx)
-	w.ContentType = "application/json"
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(body); err != nil {
-		_ = w.Close()
-		return err
-	}
-	if err := w.Close(); err != nil {
-		return err
-	}
+func writeRestoreRequestGeneric(ctx context.Context, repo Repo, snapshot string, body restoreRequestBody) error {
+    when := time.Now().UTC().Format("20060102T150405Z")
+    base := "restore-requests"
+    name := fmt.Sprintf("%s/restore_%s.json", base, when)
+    if snapshot != "" {
+        name = fmt.Sprintf("%s/restore_%s_%s.json", base, sanitizeForPath(snapshot), when)
+    }
+    w, err := repo.Writer(ctx, name, "application/json")
+    if err != nil {
+        return err
+    }
+    enc := json.NewEncoder(w)
+    enc.SetIndent("", "  ")
+    if err := enc.Encode(body); err != nil {
+        _ = w.Close()
+        return err
+    }
+    if err := w.Close(); err != nil {
+        return err
+    }
 
-	// Also write a small helper text with the REST call format
-	cmd := buildRestoreCurl(snapshot)
-	textName := strings.TrimSuffix(name, path.Ext(name)) + ".txt"
-	w2 := b.Object(textName).NewWriter(ctx)
-	w2.ContentType = "text/plain"
-	if _, err := io.WriteString(w2, cmd+"\n"); err != nil {
-		_ = w2.Close()
-		return err
-	}
-	return w2.Close()
+    // Also write a small helper text with the REST call format
+    cmd := buildRestoreCurl(snapshot)
+    textName := strings.TrimSuffix(name, path.Ext(name)) + ".txt"
+    w2, err := repo.Writer(ctx, textName, "text/plain")
+    if err != nil {
+        return err
+    }
+    if _, err := io.WriteString(w2, cmd+"\n"); err != nil {
+        _ = w2.Close()
+        return err
+    }
+    return w2.Close()
 }
 
 func buildRestoreCurl(snapshot string) string {
@@ -340,4 +402,148 @@ func sanitizeForPath(name string) string {
 	// Keep it simple: replace path separators and spaces
 	replacer := strings.NewReplacer("/", "-", "\\", "-", " ", "_")
 	return replacer.Replace(name)
+}
+
+// Repository abstraction
+
+type Repo interface {
+    List(ctx context.Context) (ObjectIterator, error)
+    Reader(ctx context.Context, name string) (io.ReadCloser, error)
+    Writer(ctx context.Context, name string, contentType string) (io.WriteCloser, error)
+    EnsureAccessible(ctx context.Context) error
+    String() string
+}
+
+type ObjectAttrs struct {
+    Name        string
+    ContentType string
+}
+
+type ObjectIterator interface {
+    Next() (*ObjectAttrs, error)
+}
+
+// GCS implementation
+type gcsRepo struct {
+    client *storage.Client
+    bucket string
+}
+
+func newGCSRepo(client *storage.Client, bucket string) Repo {
+    return &gcsRepo{client: client, bucket: bucket}
+}
+
+func (r *gcsRepo) EnsureAccessible(ctx context.Context) error {
+    _, err := r.client.Bucket(r.bucket).Attrs(ctx)
+    return err
+}
+
+func (r *gcsRepo) List(ctx context.Context) (ObjectIterator, error) {
+    it := r.client.Bucket(r.bucket).Objects(ctx, &storage.Query{})
+    return &gcsObjectIterator{it: it}, nil
+}
+
+func (r *gcsRepo) Reader(ctx context.Context, name string) (io.ReadCloser, error) {
+    return r.client.Bucket(r.bucket).Object(name).NewReader(ctx)
+}
+
+func (r *gcsRepo) Writer(ctx context.Context, name string, contentType string) (io.WriteCloser, error) {
+    w := r.client.Bucket(r.bucket).Object(name).NewWriter(ctx)
+    if contentType != "" {
+        if sw, ok := w.(*storage.Writer); ok {
+            sw.ContentType = contentType
+        }
+    }
+    return w, nil
+}
+
+func (r *gcsRepo) String() string {
+    return "gs://" + r.bucket
+}
+
+type gcsObjectIterator struct {
+    it *storage.ObjectIterator
+}
+
+func (it *gcsObjectIterator) Next() (*ObjectAttrs, error) {
+    attrs, err := it.it.Next()
+    if err != nil {
+        return nil, err
+    }
+    return &ObjectAttrs{Name: attrs.Name, ContentType: attrs.ContentType}, nil
+}
+
+// Filesystem implementation
+type fsRepo struct {
+    root string
+}
+
+func newFSRepo(root string) Repo {
+    return &fsRepo{root: root}
+}
+
+func (r *fsRepo) EnsureAccessible(ctx context.Context) error {
+    info, err := os.Stat(r.root)
+    if err != nil {
+        return err
+    }
+    if !info.IsDir() {
+        return fmt.Errorf("not a directory: %s", r.root)
+    }
+    return nil
+}
+
+func (r *fsRepo) List(ctx context.Context) (ObjectIterator, error) {
+    var names []string
+    err := filepath.WalkDir(r.root, func(p string, d os.DirEntry, err error) error {
+        if err != nil {
+            return err
+        }
+        if d.IsDir() {
+            return nil
+        }
+        rel, err := filepath.Rel(r.root, p)
+        if err != nil {
+            return err
+        }
+        // Normalize to forward slashes
+        rel = filepath.ToSlash(rel)
+        names = append(names, rel)
+        return nil
+    })
+    if err != nil {
+        return nil, err
+    }
+    return &fsObjectIterator{names: names, idx: 0}, nil
+}
+
+func (r *fsRepo) Reader(ctx context.Context, name string) (io.ReadCloser, error) {
+    p := filepath.Join(r.root, filepath.FromSlash(name))
+    return os.Open(p)
+}
+
+func (r *fsRepo) Writer(ctx context.Context, name string, contentType string) (io.WriteCloser, error) {
+    p := filepath.Join(r.root, filepath.FromSlash(name))
+    if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+        return nil, err
+    }
+    return os.Create(p)
+}
+
+func (r *fsRepo) String() string {
+    return r.root
+}
+
+type fsObjectIterator struct {
+    names []string
+    idx   int
+}
+
+func (it *fsObjectIterator) Next() (*ObjectAttrs, error) {
+    if it.idx >= len(it.names) {
+        return nil, iterator.Done
+    }
+    name := it.names[it.idx]
+    it.idx++
+    return &ObjectAttrs{Name: name, ContentType: ""}, nil
 }

--- a/main.go
+++ b/main.go
@@ -41,6 +41,8 @@ type restoreRequestBody struct {
 	IncludeGlobalState bool   `json:"include_global_state"`
 	IncludeAliases     bool   `json:"include_aliases"`
 	Partial            bool   `json:"partial"`
+    RenamePattern      string `json:"rename_pattern,omitempty"`
+    RenameReplacement  string `json:"rename_replacement,omitempty"`
 }
 
 func main() {
@@ -53,6 +55,8 @@ func main() {
         dstDir       string
 		timeframeArg string
 		grepArg      string
+        renamePattern string
+        renameReplacement string
 		maxWorkers   int
 	)
 
@@ -64,6 +68,8 @@ func main() {
     flag.StringVar(&dstDir, "dest-dir", "", "Destination local directory to receive copy and restore request (alternative to --dest-bucket)")
 	flag.StringVar(&timeframeArg, "timeframe", "", "Timeframe filter RFC3339/RFC3339 (e.g. 2025-09-01T00:00:00Z/2025-09-10T23:59:59Z)")
 	flag.StringVar(&grepArg, "grep", "", "Substring or regex to match snapshot name or index names")
+    flag.StringVar(&renamePattern, "rename-pattern", "", "Rename pattern for restore (Elasticsearch regex), e.g. 'orders-(.*)'")
+    flag.StringVar(&renameReplacement, "rename-replacement", "", "Rename replacement for restore, e.g. 'orders-restored-$1'")
 	flag.IntVar(&maxWorkers, "concurrency", 16, "Max concurrent copies")
 	flag.Parse()
 
@@ -163,6 +169,8 @@ func main() {
 		IncludeGlobalState: false,
 		IncludeAliases:     true,
 		Partial:            false,
+        RenamePattern:      renamePattern,
+        RenameReplacement:  renameReplacement,
 	}
     if err := writeRestoreRequestGeneric(ctx, dstRepo, selectedSnapshot, req); err != nil {
 		log.Fatalf("failed to write restore request: %v", err)

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SNAP_DIR="$ROOT_DIR/snapshots"
+DEST_DIR="$ROOT_DIR/snapshots_copy"
+
+rm -rf "$SNAP_DIR" "$DEST_DIR"
+mkdir -p "$SNAP_DIR" "$DEST_DIR"
+
+echo "Starting Elasticsearch via docker-compose..."
+docker compose -f "$ROOT_DIR/docker-compose.yml" up -d
+
+# Wait for ES
+echo "Waiting for Elasticsearch to be ready..."
+until curl -sSf http://localhost:9200 >/dev/null; do sleep 2; done
+sleep 5
+
+echo "Indexing seed data..."
+curl -sS -H 'Content-Type: application/x-ndjson' --data-binary @"$ROOT_DIR/test/seed.json" http://localhost:9200/_bulk | jq .errors -r
+
+echo "Registering local snapshot repo..."
+curl -sS -X PUT http://localhost:9200/_snapshot/local_repo -H 'Content-Type: application/json' -d "{\n  \"type\": \"fs\",\n  \"settings\": {\n    \"location\": \"/snapshots\",\n    \"compress\": true\n  }\n}"
+
+SNAP_NAME="snap-$(date +%s)"
+echo "Creating snapshot $SNAP_NAME..."
+curl -sS -X PUT "http://localhost:9200/_snapshot/local_repo/$SNAP_NAME?wait_for_completion=true" -H 'Content-Type: application/json' -d '{"indices":"orders-*,users-*"}' >/dev/null
+
+echo "Copying snapshot repo locally using CLI with grep 'orders-' and renaming to 'orders-restored-$1'..."
+"$ROOT_DIR/rockez-script" \
+  --src-dir "$SNAP_DIR" \
+  --dest-dir "$DEST_DIR" \
+  --grep 'orders-.*' \
+  --rename-pattern 'orders-(.*)' \
+  --rename-replacement 'orders-restored-$1' \
+  --timeframe "2000-01-01T00:00:00Z/2100-01-01T00:00:00Z"
+
+echo "Registering copied repo as local_repo_copy..."
+curl -sS -X PUT http://localhost:9200/_snapshot/local_repo_copy -H 'Content-Type: application/json' -d "{\n  \"type\": \"fs\",\n  \"settings\": {\n    \"location\": \"/snapshots_copy\",\n    \"compress\": true\n  }\n}"
+
+# Find restore request json created by the tool
+RESTORE_FILE=$(ls -1 "$DEST_DIR/restore-requests"/restore_*.json | tail -n 1)
+if [[ -z "${RESTORE_FILE:-}" ]]; then
+  echo "Restore request file not found" >&2
+  exit 1
+fi
+echo "Using restore file: $RESTORE_FILE"
+
+# Determine most recent snapshot name from the copied index.latest
+IDX_LATEST=$(cat "$DEST_DIR/index.latest")
+INDEX_FILE="$DEST_DIR/index-$IDX_LATEST"
+SNAP_NAME_JSON=$(jq -r '.snapshots[-1].snapshot' "$INDEX_FILE")
+
+echo "Restoring snapshot $SNAP_NAME_JSON with rename..."
+curl -sS -X POST "http://localhost:9200/_snapshot/local_repo_copy/$SNAP_NAME_JSON/_restore" \
+  -H 'Content-Type: application/json' \
+  --data-binary @"$RESTORE_FILE"
+
+echo "Waiting a moment for restore..."
+sleep 5
+
+echo "Verifying restored indices exist..."
+curl -sS http://localhost:9200/_cat/indices?v
+
+echo "Done."

--- a/test/seed.json
+++ b/test/seed.json
@@ -1,0 +1,6 @@
+{"index":{"_index":"orders-2025.09.10","_id":"1"}}
+{"order_id":1,"customer":"alice","total":123.45,"ts":"2025-09-10T12:00:00Z"}
+{"index":{"_index":"orders-2025.09.11","_id":"2"}}
+{"order_id":2,"customer":"bob","total":67.89,"ts":"2025-09-11T13:00:00Z"}
+{"index":{"_index":"users-2025.09.11","_id":"3"}}
+{"user_id":3,"name":"carol","ts":"2025-09-11T14:00:00Z"}


### PR DESCRIPTION
Add a Go CLI script to filter Elasticsearch GCS snapshots by timeframe and grep, then generate a restore request.

---
<a href="https://cursor.com/background-agent?bcId=bc-f61b2215-b17b-4df6-a4c0-eab47076a306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f61b2215-b17b-4df6-a4c0-eab47076a306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

